### PR TITLE
More flexible validation

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -23,9 +23,9 @@ jobs:
           DEBUG_HEADER=$(curl -s -I -H "flyio-debug: doit" "$URL" | grep "flyio-debug:")
           HTML_CONTENT=$(curl -s -H "flyio-debug: doit" "$URL")
           
-          # Extract machine IDs
+          # Extract machine IDs using regex that finds a 14-digit hex string in the content
           DEBUG_MACHINE_ID=$(echo "$DEBUG_HEADER" | grep -o '"sid":"[^"]*"' | cut -d'"' -f4)
-          HTML_MACHINE_ID=$(echo "$HTML_CONTENT" | grep -A1 'Machine ID' | grep -o '<dd.*</dd>' | sed 's/<[^>]*>//g' | xargs)
+          HTML_MACHINE_ID=$(echo "$HTML_CONTENT" | grep -oP '[0-9a-f]{14}' | head -n 1)
           
           # Validate connection and status
           if ! curl --connect-timeout 10 -s -o /dev/null "$URL"; then


### PR DESCRIPTION
I noticed the links in the hiring email didn't match and got curious, did some additional research before submitting feedback to Luke

> You're going to complete the support engineer challenge tasks detailed in this repo (https://github.com/fly-hiring/support-engineer-challenge). We just invited you to your own private copy at https://github.com/fly-hiring/120440. The readme has instructions and info to get you started. Do all of your work in your private copy then tell us when you're done.

https://github.com/fly-hiring/support-engineer-challenge is the archived challenge with the rails challenge along with a support engineer mock interactions, you'll likely want to update this in your Support Engineer email template.

I also found that I broke @kylemclaren's automated check to extract the `MACHINE_ID` in my submission, sorry about that 😅
- https://github.com/fly-hiring/120440/commit/109c5ebcb2aefeed473bd4fe7102f0cbb8a76fa2
- https://120440.fly.dev/

This tweak finds a 14-digit hex to compare to the debug string making the automated check more resilient as it doesn't rely on specific HTML tags